### PR TITLE
[doc] Include TARGET_LANGUAGE env var name in README for downloader

### DIFF
--- a/l10n/poeditor-download/README.md
+++ b/l10n/poeditor-download/README.md
@@ -15,7 +15,7 @@ To update all language files in `$APP_LOCALE_PATH`, run the script as specified 
 env POEDITOR_PROJECT_ID=12345 APP_LOCALE_PATH="~/dev/www.zetkin.in/locale" `cat ../.env` ./update-all-languages.py
 ```
 
-Update English and Swedish translations:
+Use the `$TARGET_LANGUAGE` environment variable to limit the update. This example limits the update to English and Swedish translations:
 
 ```
 env POEDITOR_PROJECT_ID=12345 APP_LOCALE_PATH="~/dev/www.zetkin.in/locale" `cat ../.env` TARGET_LANGUAGE=en,sv ./update-all-languages.py


### PR DESCRIPTION
This PR adds more explicit documentation, by being redundant in an example.

