### PR TITLE
Fix empty TARGET_LANGUAGE

### DIFF
--- a/l10n/poeditor-upload/update-all-languages.py
+++ b/l10n/poeditor-upload/update-all-languages.py
@@ -22,10 +22,18 @@ def poeditor_http_request(url, post_dict):
     return clean_response
 
 def get_langs():
+    langs = None
+
     try:
-        langs = os.environ['TARGET_LANGUAGE'].split(',')
+        lang_spec = os.environ['TARGET_LANGUAGE']
+        if len(lang_spec) > 0:
+            langs = lang_spec.split(',')
     except KeyError:
+        pass
+
+    if langs is None:
         langs = get_local_langs()
+
     return langs
 
 def get_local_langs():


### PR DESCRIPTION
Fix case where `TARGET_LANGUAGE` is set to empty string. This is the default case in the new dockerized setup. Previously, when the `TARGET_LANGUAGE` was an empty string, no exception would be thrown causing the result of `get_langs()` being an array of a single empty string (`['']`) rather than the default local languages.