### PR TITLE
Environment variable defaulting, style

### DIFF
--- a/l10n/poeditor-download/update-all-languages.py
+++ b/l10n/poeditor-download/update-all-languages.py
@@ -28,26 +28,20 @@ def poeditor_http_request(url, post_dict):
 
 
 def get_langs():
-    langs = None
-
-    try:
-        lang_spec = os.environ['TARGET_LANGUAGE']
-        if len(lang_spec) > 0:
-            langs = lang_spec.split(',')
-    except KeyError:
-        pass
-
-    if langs is None:
+    lang_spec = os.environ.get('TARGET_LANGUAGE')
+    if len(lang_spec) > 0:
+        return lang_spec.split(',')
+    else:
         lang_list_data = get_poeditor_langs()
-        langs = parse_poeditor_lang_list(lang_list_data)
-
-    return langs
+        return parse_poeditor_lang_list(lang_list_data)
 
 
 def get_poeditor_langs():
     get_langs_url = 'https://api.poeditor.com/v2/languages/list'
-    post_dict = {'api_token': os.environ['POEDITOR_API_KEY'],
-            'id': os.environ['POEDITOR_PROJECT_ID']}
+    post_dict = {
+        'api_token': os.environ['POEDITOR_API_KEY'],
+        'id': os.environ['POEDITOR_PROJECT_ID']
+    }
 
     lang_list_data = poeditor_http_request(get_langs_url, post_dict)
     return lang_list_data
@@ -60,9 +54,11 @@ def parse_poeditor_lang_list(lang_list_data):
 
 def get_lang_data(lang):
     lang_data_url = 'https://api.poeditor.com/v2/terms/list'
-    post_dict = {'api_token': os.environ['POEDITOR_API_KEY'],
-            'id': os.environ['POEDITOR_PROJECT_ID'],
-            'language': lang}
+    post_dict = {
+        'api_token': os.environ.get('POEDITOR_API_KEY'),
+        'id': os.environ.get('POEDITOR_PROJECT_ID'),
+        'language': lang
+    }
 
     lang_data = poeditor_http_request(lang_data_url, post_dict)
     return lang_data

--- a/l10n/poeditor-upload/update-all-languages.py
+++ b/l10n/poeditor-upload/update-all-languages.py
@@ -26,19 +26,11 @@ def poeditor_http_request(url, post_dict):
 
 
 def get_langs():
-    langs = None
-
-    try:
-        lang_spec = os.environ['TARGET_LANGUAGE']
-        if len(lang_spec) > 0:
-            langs = lang_spec.split(',')
-    except KeyError:
-        pass
-
-    if langs is None:
-        langs = get_local_langs()
-
-    return langs
+    lang_spec = os.environ.get('TARGET_LANGUAGE')
+    if lang_spec and len(lang_spec) > 0:
+        return lang_spec.split(',')
+    else:
+        return get_local_langs()
 
 
 def get_local_langs():
@@ -52,9 +44,11 @@ def get_local_langs():
 
 def get_poeditor_lang_data(lang):
     url = 'https://api.poeditor.com/v2/terms/list'
-    post_dict = {'api_token': os.environ['POEDITOR_API_KEY'],
-            'id': os.environ['POEDITOR_PROJECT_ID'],
-            'language': lang}
+    post_dict = {
+        'api_token': os.environ['POEDITOR_API_KEY'],
+        'id': os.environ['POEDITOR_PROJECT_ID'],
+        'language': lang
+    }
 
     response = poeditor_http_request(url, post_dict)
     return response
@@ -79,10 +73,12 @@ def get_all_poeditor_terms_all_langs(langs=['en']):
 
 def poeditor_add_terms(data):
     url = 'https://api.poeditor.com/v2/terms/add'
-    post_dict = {'api_token': os.environ['POEDITOR_API_KEY'],
-            'id': os.environ['POEDITOR_PROJECT_ID'],
-            'data': data,
-            'fuzzy': '1'}
+    post_dict = {
+        'api_token': os.environ['POEDITOR_API_KEY'],
+        'id': os.environ['POEDITOR_PROJECT_ID'],
+        'data': data,
+        'fuzzy': '1'
+    }
 
     response = poeditor_http_request(url, post_dict)
     return response
@@ -245,13 +241,10 @@ def handle_translation_update(langs, translated_terms, verbose=False):
 
 
 def get_verbosity():
-    try:
-        verbose_env = os.environ['POEDITOR_SCRIPT_VERBOSE']
-        if len(verbose_env) > 0:
-            verbose = bool(int(verbose_env))
-            return verbose
-    except KeyError:
-        return False
+    verbose_env = os.environ.get('POEDITOR_SCRIPT_VERBOSE', '0')
+    if len(verbose_env) > 0:
+        return bool(int(verbose_env))
+    return False
 
 
 def main():


### PR DESCRIPTION
This PR is about reading environment variables with less try/except.

  - use `os.environ.get(KEY, 'default-value')` in some places
  - keep the `[]` access where we SHOULD fail on missing the value
  - style: let dictionaries take up more vertical space